### PR TITLE
middleware: allow raw dumps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    stackprof (0.2.6)
+    stackprof (0.2.7)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/stackprof/middleware.rb
+++ b/lib/stackprof/middleware.rb
@@ -11,12 +11,13 @@ module StackProf
       Middleware.interval = options[:interval] || 1000
       Middleware.enabled  = options[:enabled]
       Middleware.path     = options[:path] || 'tmp'
+      Middleware.raw      = options[:raw] || false
       at_exit{ Middleware.save } if options[:save_at_exit]
     end
 
     def call(env)
       enabled, mode = Middleware.enabled?
-      StackProf.start(mode: mode || Middleware.mode, interval: Middleware.interval) if enabled
+      StackProf.start(mode: mode || Middleware.mode, raw: Middleware.raw, interval: Middleware.interval) if enabled
       @app.call(env)
     ensure
       if enabled
@@ -29,7 +30,7 @@ module StackProf
     end
 
     class << self
-      attr_accessor :enabled, :mode, :interval, :path
+      attr_accessor :enabled, :mode, :interval, :path, :raw
 
       def enabled?
         if enabled.respond_to?(:call)

--- a/test/test_middleware.rb
+++ b/test/test_middleware.rb
@@ -53,10 +53,23 @@ class StackProf::MiddlewareTest < Test::Unit::TestCase
     assert enabled
     assert_equal 'foo', mode
 
-    StackProf.expects(:start).with({mode: 'foo', interval: StackProf::Middleware.interval})
+    StackProf.expects(:start).with({mode: 'foo', interval: StackProf::Middleware.interval, raw: false})
     StackProf.expects(:stop)
 
     middleware.call(nil)
+    assert proc_called
+  end
+
+  def test_raw_should_start_with_raw
+    proc_called = false
+
+    middleware = StackProf::Middleware.new(proc { |env| proc_called = true }, enabled: [true, 'foo'], raw: true)
+
+    StackProf.expects(:start).with({mode: 'foo', interval: StackProf::Middleware.interval, raw: true})
+    StackProf.expects(:stop)
+
+    middleware.call(nil)
+
     assert proc_called
   end
 


### PR DESCRIPTION
Allows dumping the raw profile for more in depth analysis. Also forked this to Shopify, because not everyone from Shopify can modify Camilo's fork.

@csfrancis @camilo 