### PR TITLE
ensure raw is present in joined output

### DIFF
--- a/lib/stackprof/report.rb
+++ b/lib/stackprof/report.rb
@@ -12,14 +12,29 @@ module StackProf
       Hash[ *@data[:frames].sort_by{ |iseq, stats| -stats[sort_by_total ? :total_samples : :samples] }.flatten(1) ]
     end
 
+    # normalized frames is used when we want to combine multiple
+    # output files, (via +() below). In order to simplify combination
+    # of files that are from "different" source revisions, the frames
+    # are normalised by converting them to an MD5 using the "name, file, line"
+    # once frames are converted, every edge that references the original
+    # needs to adjusted also.
     def normalized_frames
       id2hash = {}
       @data[:frames].each do |frame, info|
+        # id2 hash contains the original frames converted into a MD5
+        # based on the name, file, line of the original frame
         # flamegraph likes the frames to be numbers, so md5.to_i(16)
         id2hash[frame.to_s] = info[:hash] = Digest::MD5.hexdigest("#{info[:name]}#{info[:file]}#{info[:line]}").to_i(16)
       end
-      # include raw also
+      # Convert all existing raw frames to use the new mapping via id2hash
+      # the array of raw frames contains a sequence of frame slices. Each
+      # frame slice is preceded by a count of the number of subsequent frames
+      # in the slice. Since the counts need not be normalized and we can
+      # identify frames by looking for a mapping in id2hash, add the
+      # normalized frame value when it is available, and just copy the
+      # existing value otherwise
       raw_frames = @data[:raw].map {|v| id2hash[v.to_s] || v } if @data[:raw]
+      # return both the normalized frames and the normalized raw frames
       return @data[:frames].inject(Hash.new) do |hash, (frame, info)|
         info = hash[id2hash[frame.to_s]] = info.dup
         info[:edges] = info[:edges].inject(Hash.new){ |edges, (edge, weight)| edges[id2hash[edge.to_s]] = weight; edges } if info[:edges]
@@ -293,6 +308,7 @@ module StackProf
       raise ArgumentError, "cannot combine #{modeline} with #{other.modeline}" unless modeline == other.modeline
       raise ArgumentError, "cannot combine v#{version} with v#{other.version}" unless version == other.version
 
+      # collect the normalized and the normalized raw frames
       f1, raw_frames1 = normalized_frames
       f2, raw_frames2 = other.normalized_frames
       frames = (f1.keys + f2.keys).uniq.inject(Hash.new) do |hash, id|
@@ -322,6 +338,8 @@ module StackProf
       end
 
       d1, d2 = data, other.data
+      # ensure that the new data contains the normalized frames
+      # and the normalized raw frames also
       data = {
         version: version,
         mode: d1[:mode],


### PR DESCRIPTION
Essentially when stackprof concatenates files together, it normalises the frames from each "file" using an MD5 based on file/line etc. For raw data there are two problems

a) raw data was not being output to the "combined" file
b) raw frames were not being normalised.

This change does the above two things. This is an upstream issue, but without this, generating raw frames for "flamegraphs" is hit-and-miss. (hit-and-miss because it depends on whether the data that was collected in the middleware was multiple files or just one file).

@fbogsany @csfrancis @camilo

This works generating raw frames and flamegraphs each time now. :-)

This is similar to the earlier request, except that it is for shopify/stackprof master. The previous one was a diff against 0.28, which I will do separately. 

I plan to open this issue for the upstream code also.