### PR TITLE
Fix Fixnum deprecation warning

### DIFF
--- a/lib/stackprof/report.rb
+++ b/lib/stackprof/report.rb
@@ -72,8 +72,8 @@ module StackProf
 
     def add_lines(a, b)
       return b if a.nil?
-      return a+b if a.is_a? Fixnum
-      return [ a[0], a[1]+b ] if b.is_a? Fixnum
+      return a+b if a.is_a? Integer
+      return [ a[0], a[1]+b ] if b.is_a? Integer
       [ a[0]+b[0], a[1]+b[1] ]
     end
 


### PR DESCRIPTION
Upstream patch: https://github.com/tmm1/stackprof/commit/12efe32a412df3dbbf8033c72d29ca0404db9910#diff-fc439995f354505a6ef7dc1042b4640f

It produce this annoying warning:

```

/tmp/bundle/ruby/2.5.0/bundler/gems/stackprof-59d74a6d0a86/lib/stackprof/report.rb:75: warning: constant ::Fixnum is deprecated
/tmp/bundle/ruby/2.5.0/bundler/gems/stackprof-59d74a6d0a86/lib/stackprof/report.rb:76: warning: constant ::Fixnum is deprecated
```